### PR TITLE
Fix viewing drafts bug w/ nothing is published in current language

### DIFF
--- a/godtools/Controllers/GTHomeViewController.m
+++ b/godtools/Controllers/GTHomeViewController.m
@@ -180,7 +180,7 @@
     
     [self setData];
 
-    if(![self languageHasLivePackages:[self getCurrentPrimaryLanguage]]) {
+    if(![self isTranslatorMode] && ![self languageHasLivePackages:[self getCurrentPrimaryLanguage]]) {
         self.languageCode = @"en";
         [[GTDefaults sharedDefaults] setCurrentLanguageCode:@"en" ];
         [self setData];


### PR DESCRIPTION
The line of code updated introduced a bug where it was not possible for a translator to view drafts in a language with nothing published.

The intention was to prevent a user who was in preview mode w/ nothing published from viewing a blank home page when leaving translator mode.  The trick of course is to not switch the language when the user is actually in translator mode.
