### PR TITLE
GT-167 Follow Up API client

### DIFF
--- a/godtools.xcodeproj/project.pbxproj
+++ b/godtools.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		498E2278AF98C76BDF632C70 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 74F8066D3A00B27C587FD9D9 /* libPods.a */; };
 		4F0C465A1CAEECDD007581A8 /* GTFollowUpSubscription.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F0C46571CAEECDD007581A8 /* GTFollowUpSubscription.m */; };
 		4F0C465B1CAEECDD007581A8 /* GTFollowUpSubscription+CoreDataProperties.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F0C46591CAEECDD007581A8 /* GTFollowUpSubscription+CoreDataProperties.m */; };
+		4F204CB01CB2B0F800F1CBD7 /* FollowUpAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F204CAF1CB2B0F800F1CBD7 /* FollowUpAPI.m */; };
 		4F20B3D31AC9A2F60026DC9E /* EveryStudent.xml in Resources */ = {isa = PBXBuildFile; fileRef = 4F20B3C51AC9A2F60026DC9E /* EveryStudent.xml */; };
 		4F20B3D41AC9A2F60026DC9E /* EveryStudentArticleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F20B3C71AC9A2F60026DC9E /* EveryStudentArticleView.m */; };
 		4F20B3D51AC9A2F60026DC9E /* EveryStudentArticleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4F20B3C81AC9A2F60026DC9E /* EveryStudentArticleView.xib */; };
@@ -128,6 +129,8 @@
 		4F0C46571CAEECDD007581A8 /* GTFollowUpSubscription.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = GTFollowUpSubscription.m; path = "follow-up-api/Models/GTFollowUpSubscription.m"; sourceTree = "<group>"; };
 		4F0C46581CAEECDD007581A8 /* GTFollowUpSubscription+CoreDataProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "GTFollowUpSubscription+CoreDataProperties.h"; path = "follow-up-api/Models/GTFollowUpSubscription+CoreDataProperties.h"; sourceTree = "<group>"; };
 		4F0C46591CAEECDD007581A8 /* GTFollowUpSubscription+CoreDataProperties.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "GTFollowUpSubscription+CoreDataProperties.m"; path = "follow-up-api/Models/GTFollowUpSubscription+CoreDataProperties.m"; sourceTree = "<group>"; };
+		4F204CAE1CB2B0D400F1CBD7 /* FollowUpAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FollowUpAPI.h; path = "follow-up-api/FollowUpAPI.h"; sourceTree = "<group>"; };
+		4F204CAF1CB2B0F800F1CBD7 /* FollowUpAPI.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FollowUpAPI.m; path = "follow-up-api/FollowUpAPI.m"; sourceTree = "<group>"; };
 		4F20B3C51AC9A2F60026DC9E /* EveryStudent.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = EveryStudent.xml; path = Controllers/EveryStudent/EveryStudent.xml; sourceTree = "<group>"; };
 		4F20B3C61AC9A2F60026DC9E /* EveryStudentArticleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EveryStudentArticleView.h; path = Controllers/EveryStudent/EveryStudentArticleView.h; sourceTree = "<group>"; };
 		4F20B3C71AC9A2F60026DC9E /* EveryStudentArticleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EveryStudentArticleView.m; path = Controllers/EveryStudent/EveryStudentArticleView.m; sourceTree = "<group>"; };
@@ -279,6 +282,8 @@
 			isa = PBXGroup;
 			children = (
 				4F0C46551CAEEC3B007581A8 /* Models */,
+				4F204CAE1CB2B0D400F1CBD7 /* FollowUpAPI.h */,
+				4F204CAF1CB2B0F800F1CBD7 /* FollowUpAPI.m */,
 			);
 			name = "followup-api";
 			sourceTree = "<group>";
@@ -835,6 +840,7 @@
 				4F20B3D91AC9A2F60026DC9E /* EveryStudentItemsController.m in Sources */,
 				B7D2AF8E1A43F131009B7D5B /* GTSettingsAboutGodToolsViewController.m in Sources */,
 				4F20B3DB1AC9A2F60026DC9E /* EveryStudentSearchCell.m in Sources */,
+				4F204CB01CB2B0F800F1CBD7 /* FollowUpAPI.m in Sources */,
 				4F20B3D61AC9A2F60026DC9E /* EveryStudentCell.m in Sources */,
 				4FE1E6E51ADEF69700133A3E /* GTGoogleAnalyticsTracker.m in Sources */,
 				B76536DA1A0CD2CF001C3FC3 /* GTLanguageViewCell.m in Sources */,

--- a/godtools/en.lproj/Main.storyboard
+++ b/godtools/en.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="OvA-bH-obN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="OvA-bH-obN">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>

--- a/godtools/follow-up-api/FollowUpAPI.h
+++ b/godtools/follow-up-api/FollowUpAPI.h
@@ -1,0 +1,25 @@
+//
+//  FollowUpAPI.h
+//  godtools
+//
+//  Created by Ryan Carlson on 4/4/16.
+//  Copyright © 2016 Michael Harrison. All rights reserved.
+//
+
+#import "AFHTTPRequestOperationManager.h"
+
+#import "GTConfig.h"
+
+#import "GTFollowUpSubscription.h"
+
+@interface FollowUpAPI : AFHTTPRequestOperationManager
+
++ (instancetype)sharedAPI;
+
+- (instancetype)initWithConfig:(GTConfig *)config;
+
+- (BOOL)isReachable;
+
+- (void)sendNewSubscription:(GTFollowUpSubscription *)subscriber;
+- (void)sendNewSubscription:(GTFollowUpSubscription *)subscriber onSuccess:(void (^)(AFHTTPRequestOperation *, id))successBlock onFailure:(void (^)(AFHTTPRequestOperation *, id)) failureBlock;
+@end

--- a/godtools/follow-up-api/FollowUpAPI.m
+++ b/godtools/follow-up-api/FollowUpAPI.m
@@ -1,0 +1,79 @@
+//
+//  FollowUpAPI.m
+//  godtools
+//
+//  Created by Ryan Carlson on 4/4/16.
+//  Copyright © 2016 Michael Harrison. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "FollowUpAPI.h"
+#import "AFURLResponseSerialization.h"
+
+@interface FollowUpAPI()
+
+
+@end
+
+@implementation FollowUpAPI
+
++ (instancetype)sharedAPI {
+    static FollowUpAPI *_sharedAPI = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+       
+        _sharedAPI = [[FollowUpAPI alloc] initWithConfig:[GTConfig sharedConfig]];
+    });
+    
+    return _sharedAPI;
+}
+
+
+- (instancetype)initWithConfig:(GTConfig *)config {
+    self = [self initWithBaseURL:config.followUpApiUrl];
+    
+    [self.requestSerializer setValue:config.followUpApiSharedKey
+                  forHTTPHeaderField:@"Access-Id"];
+    
+    [self.requestSerializer setValue:config.followUpApiSecretKey
+                  forHTTPHeaderField:@"Access-Secret"];
+    
+    [self.requestSerializer setValue:@"application/x-www-form-urlencoded"
+                  forHTTPHeaderField:@"Content-Type"];
+    
+    self.reachabilityManager = [AFNetworkReachabilityManager managerForDomain:config.followUpApiUrl.host];
+    [self.reachabilityManager startMonitoring];
+    
+    self.responseSerializer = [AFJSONResponseSerializer serializer];
+    
+    return self;
+}
+
+
+- (BOOL) isReachable {
+    return self.reachabilityManager.isReachable;
+}
+
+
+- (void)sendNewSubscription:(GTFollowUpSubscription *)subscriber {
+    // validate email is present
+    
+    [self sendNewSubscription:subscriber
+                    onSuccess:nil
+                    onFailure:nil];
+}
+
+- (void)sendNewSubscription:(GTFollowUpSubscription *)subscriber onSuccess:(void (^)(AFHTTPRequestOperation *, id))successBlock onFailure:(void (^)(AFHTTPRequestOperation *, NSError *)) failureBlock {
+    
+    NSDictionary *parameters = @{@"route_id" : [GTConfig sharedConfig].followUpApiDefaultRouteId,
+                                 @"language_code" : subscriber.languageCode,
+                                 @"email" : subscriber.emailAddress};
+    
+    [self POST:@"subscribers"
+    parameters:parameters
+       success:successBlock
+       failure:failureBlock];
+}
+
+@end

--- a/godtools/follow-up-api/Models/GTFollowUpSubscription.h
+++ b/godtools/follow-up-api/Models/GTFollowUpSubscription.h
@@ -15,10 +15,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface GTFollowUpSubscription : NSManagedObject
 
 - (NSArray *)loadSubscriptionsNeedingAPITranmission;
+
 - (instancetype)createNewSubscription;
 - (instancetype)createNewSubscriptionForEmail:(NSString *)emailAddress toRoute:(NSString *)routeId;
 - (instancetype)createNewSubscriptionForEmail:(NSString *)emailAddress toRoute:(NSString *)routeId withContext:(NSString *)contextId andFollowUp:(NSString *)followUpId;
-
+- (instancetype)createNewSubscriptionForEmail:(NSString *)emailAddress inLanguage:(NSString *)language toRoute:(NSString *) routeId;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/godtools/follow-up-api/Models/GTFollowUpSubscription.m
+++ b/godtools/follow-up-api/Models/GTFollowUpSubscription.m
@@ -11,7 +11,7 @@
 @implementation GTFollowUpSubscription
 
 - (NSArray *)loadSubscriptionsNeedingAPITranmission {
-    return [GTFollowUpSubscription MR_findAllWithPredicate:[NSPredicate predicateWithFormat:@"!apiTransmissionSuccess"]];
+    return [GTFollowUpSubscription MR_findAll];
 }
 
 
@@ -37,6 +37,15 @@
                                                                        toRoute:routeId];
     subscription.contextId = contextId;
     subscription.followUpId = followUpId;
+    
+    return subscription;
+}
+
+- (instancetype)createNewSubscriptionForEmail:(NSString *)emailAddress inLanguage:(NSString *)language toRoute:(NSString *) routeId {
+    GTFollowUpSubscription *subscription = [self createNewSubscriptionForEmail:emailAddress
+                                                                       toRoute:routeId];
+    
+    subscription.languageCode = language;
     
     return subscription;
 }

--- a/godtools/godtools-ios-api/Models/GTConfig.h
+++ b/godtools/godtools-ios-api/Models/GTConfig.h
@@ -19,6 +19,11 @@
 @property (nonatomic, strong, readonly) NSString	*apiKeyGoogleAnalytics;
 @property (nonatomic, strong, readonly) NSString	*apiKeyNewRelic;
 
+@property (nonatomic, strong, readonly) NSURL       *followUpApiUrl;
+@property (nonatomic, strong, readonly) NSString    *followUpApiSharedKey;
+@property (nonatomic, strong, readonly) NSString    *followUpApiSecretKey;
+@property (nonatomic, strong, readonly) NSString    *followUpApiDefaultRouteId;
+
 + (GTConfig *)sharedConfig;
 
 @end

--- a/godtools/godtools-ios-api/Models/GTConfig.m
+++ b/godtools/godtools-ios-api/Models/GTConfig.m
@@ -52,7 +52,15 @@
 		_apiKeyGoogleAnalytics			= ( [configDictionary valueForKey:@"google_analytics_api_key"] ? [configDictionary valueForKey:@"google_analytics_api_key"] : @"" );
 		_apiKeyNewRelic					= ( [configDictionary valueForKey:@"newrelic_api_key"] ? [configDictionary valueForKey:@"newrelic_api_key"] : @"" );
 
-		
+		//set follow api values
+        _followUpApiUrl = ([configDictionary valueForKey:@"follow_up_api_url_base"] ? [NSURL URLWithString:[configDictionary valueForKey:@"follow_up_api_url_base"]] : [NSURL URLWithString:@""]);
+        
+        _followUpApiSharedKey = ([configDictionary valueForKey:@"follow_up_api_shared_key"] ?: @"");
+
+        _followUpApiSecretKey = ([configDictionary valueForKey:@"follow_up_api_secret_key"] ?: @"");
+        
+        _followUpApiDefaultRouteId = ([configDictionary valueForKey:@"follow_up_api_default_route_id"] ?: @"");
+
     }
 	
     return self;

--- a/godtools/godtools-ios-api/config.sample.plist
+++ b/godtools/godtools-ios-api/config.sample.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>follow_up_api_secret_key</key>
+	<string></string>
+	<key>follow_up_api_shared_key</key>
+	<string></string>
+	<key>follow_up_api_url_base</key>
+	<string>https://www.growthspaces.org/api/v1/</string>
+	<key>follow_up_api_default_route_id</key>
+	<string>1</string>
 	<key>newrelic_api_key</key>
 	<string></string>
 	<key>google_analytics_api_key</key>


### PR DESCRIPTION
Adds an API client using AFNetworking that builds on top of the Data Model and DAO that were added in #33 
- API client will track reachability of the follow up API
- It will post data in www-form-urlencoded
- upon success/failure it will record the status of the request and ensure it gets saved.
