### PR TITLE
Hotfix/nav bar selector

### DIFF
--- a/godtools/Controllers/GTHomeViewController.m
+++ b/godtools/Controllers/GTHomeViewController.m
@@ -120,20 +120,19 @@ NSString *const GTHomeViewControllerShareCampaignName          = @"app-sharing";
 									   otherButtonTitles:NSLocalizedString(@"draft_publish_confirm", nil), nil];
     
     [self checkPhonesLanguage];
-    
-    // set navigation bar text and chevron color
-    [self.navigationController.navigationBar setTintColor:[UIColor whiteColor]];
-    // set navigation bar background color
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:0.67 green:0.93 blue:0.93 alpha:1.0]];
-    [self.navigationController.navigationBar setTranslucent:NO]; // required for iOS7
 }
 
 -(void)viewWillAppear:(BOOL)animated{
     [super viewWillAppear:animated];
-        
-    [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:0.2 green:0.2 blue:0.2 alpha:1.0]];
+    
     [self.navigationController.navigationBar setTintColor:[UIColor colorWithRed: 0.0 green:0.5 blue:1.0 alpha:1.0]];
-    [self.navigationController.navigationBar setTranslucent:YES]; // required for iOS7
+    
+    if ([self.navigationController.navigationBar respondsToSelector:@selector(setBarTintColor:)] &&
+        [self.navigationController.navigationBar respondsToSelector:@selector(setTranslucent:)]) {
+        [self.navigationController.navigationBar setBarTintColor:[UIColor colorWithRed:0.2 green:0.2 blue:0.2 alpha:1.0]];
+        [self.navigationController.navigationBar setTranslucent:YES]; // required for iOS7
+    }
+    
     self.navigationController.navigationBar.topItem.title = nil;
     
     [self.navigationController setNavigationBarHidden:YES];

--- a/godtools/godtools-Info.plist
+++ b/godtools/godtools-Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.1.3</string>
+	<string>4.1.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>17</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
Fixes crashes on pre-iOS 7.0 devices that try to use the app.  These lines require iOS 7.0+ specific features.
